### PR TITLE
Revert "Update dependency eza-community/eza to v0.21.4"

### DIFF
--- a/.config/aqua/aqua.yaml
+++ b/.config/aqua/aqua.yaml
@@ -18,7 +18,7 @@ packages:
 - name: sharkdp/fd@v10.2.0
 - name: BurntSushi/ripgrep@14.1.1
 - name: oberblastmeister/trashy@v2.0.0
-- name: eza-community/eza@0.21.4
+- name: eza-community/eza@0.21.3
 - name: LuaLS/lua-language-server@3.14.0
 - name: jqlang/jq@jq-1.8.0
 - name: sharkdp/pastel@v0.10.0


### PR DESCRIPTION
`error: could not find `eza` in registry `crates-io` with version `=0.21.4``